### PR TITLE
Improve database fetchAll() method

### DIFF
--- a/src/Core/Database/Database.php
+++ b/src/Core/Database/Database.php
@@ -53,8 +53,7 @@ class Database
         if ($class === null) {
             $q->setFetchMode(PDO::FETCH_OBJ);
         } else {
-            $entity = new $class();
-            $q->setFetchMode(PDO::FETCH_INTO, $entity);
+            $q->setFetchMode(PDO::FETCH_CLASS|PDO::FETCH_PROPS_LATE, $class);
         }
         if ($one) {
             $data = $q->fetch();

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -17,7 +17,7 @@ class User extends BaseEntity
     private ?string $lastname = null;
     private ?string $email = null;
     private ?string $password = null;
-    private array $roles = [];
+    private array $userroles = [];
     private ?string $lastLogin = null;
     private ?string $confirmedAt = null;
     private ?int $numberLogin = null;
@@ -110,7 +110,7 @@ class User extends BaseEntity
 
     public function getRoles(): array
     {
-        return $this->roles;
+        return $this->userroles;
     }
 
 
@@ -121,10 +121,10 @@ class User extends BaseEntity
     public function setRoles($roles): self
     {
         if (is_array($roles)) {
-            $this->roles = $roles;
+            $this->userroles = $roles;
         } else {
             $dataTransformer = new DataTransformer();
-            $this->roles = $dataTransformer->stringArrayToArray($roles);
+            $this->userroles = $dataTransformer->stringArrayToArray($roles);
         }
         return $this;
     }
@@ -132,12 +132,12 @@ class User extends BaseEntity
 
     public function addRoles(array $roles): self
     {
-        if ($this->roles[0] === '') {
-            array_shift($this->roles);
+        if ($this->userroles[0] === '') {
+            array_shift($this->userroles);
         }
         foreach ($roles as $role) {
-            if (!in_array($role, $this->roles)) {
-                $this->roles[] = $role;
+            if (!in_array($role, $this->userroles)) {
+                $this->userroles[] = $role;
             }
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix ? | NO
| New feature ? | NO
| Improvement ? | YES
| Licence | MIT


### What's in this PR ?
This PR contains a improvement of the fetchAll() method of the Database. Now it use the PDO::FETCH_CLASS (in association with PDO::FETCH_PROPS_LATE), mainly to avoid some bugs when getting all data from a database table.
The modification of the User entity was mandatory to fix a problem : a property name can't have the same name as in the database if it's not the same type (e.g. `roles` is array type into the entity, and it's string type into the database)


### Todo
- [x] Create a tag release